### PR TITLE
Persist redis db to host volume. This keeps the workers saved between…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ data/Service*
 data/computejobs/*
 data/registry/docker
 data/ServiceStorage*
+data/redis
 .cloudcomputecannon
 client.py
 results

--- a/bin/run-tests-aws
+++ b/bin/run-tests-aws
@@ -1,7 +1,6 @@
 #!/usr/bin/env sh
-rsync -av --exclude=node_modules --exclude=.git --exclude=tmp --exclude=.haxelib --exclude=.cloudcomputecannon --exclude=data/computejobs/* --exclude=data/registry/* --exclude=data/ServiceStorageLocalFileSystem/* --exclude=.vagrant --exclude=.bundle ./ serverstable:ccc/
+rsync -av --exclude=node_modules --exclude=.git --exclude=tmp --exclude=.haxelib --exclude=.cloudcomputecannon --exclude=data/computejobs/* --exclude=data/registry/* --exclude=data/redis --exclude=data/ServiceStorageLocalFileSystem/* --exclude=.vagrant --exclude=.bundle ./ serverstable:ccc/
 COMPUTE_CONFIG=`cat serverconfig.yml`
 DOCKER_COMPOSE="/opt/bin/docker-compose"
 COMMAND="$DOCKER_COMPOSE rm -fv && $DOCKER_COMPOSE build && COMPUTE_CONFIG=\`cat serverconfig.yml\` $DOCKER_COMPOSE -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.test.remote.yml up --abort-on-container-exit"
 ssh serverstable "cd ccc && $COMMAND"
-

--- a/bin/run-tests-local
+++ b/bin/run-tests-local
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-docker-compose rm -fv && docker-compose build && HOST_PWD=`pwd` docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.test.local.yml up --abort-on-container-exit
+docker-compose rm -fv && docker-compose build && docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.test.local.yml up --abort-on-container-exit
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,7 +23,9 @@ redis:
   #This config disables persistance to disk since we do not need it for development
   command: redis-server /usr/local/etc/redis/redis.conf
   volumes:
-    - ./etc/redis/redis-dev.conf:/usr/local/etc/redis/redis.conf
+    - ./etc/redis/redis-prod.conf:/usr/local/etc/redis/redis.conf
+    # This is the where the db will be writting. It is defined in ./etc/redis/redis-prod.conf
+    - ./data/redis:/data
   ports:
     - "6379:6379"
   links:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,7 +27,7 @@ redis:
   volumes:
     - ./etc/redis/redis-prod.conf:/usr/local/etc/redis/redis.conf
     # This is the where the db will be writting. It is defined in ./etc/redis/redis-prod.conf
-    - /data
+    - ./data/redis:/data
   ports:
     #Don't expose this port to the host, only linked containers.
     - "6379"

--- a/etc/redis/redis-prod.conf
+++ b/etc/redis/redis-prod.conf
@@ -58,7 +58,7 @@
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
 # JUST COMMENT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-bind 127.0.0.1
+#bind 127.0.0.1
 
 # Protected mode is a layer of security protection, in order to avoid that
 # Redis instances left open on the internet are accessed and exploited.
@@ -560,7 +560,7 @@ slave-priority 100
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-appendonly no
+appendonly yes
 
 # The name of the append only file (default: "appendonly.aof")
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cli-color": "^1.1.0",
     "commander": "^2.9.0",
     "cors": "^2.7.1",
-    "dockerode": "^2.2.9",
+    "dockerode": "^2.2.10",
     "elasticsearch": "^11.0.1",
     "eventemitter3": "^1.2.0",
     "express": "^4.12.3",

--- a/src/haxe/util/DockerTools.hx
+++ b/src/haxe/util/DockerTools.hx
@@ -536,7 +536,8 @@ class DockerTools
 				Reflect.setField(opts.PortBindings, '${port}/tcp', [{HostPort:Std.string(ports[port])}]);
 			}
 		}
-		container.start(opts, promise.cb2);
+		// container.start(opts, promise.cb2);
+		container.start(promise.cb2);
 		return promise
 			.thenVal(container);
 	}

--- a/test/src/TestsIntegration.hx
+++ b/test/src/TestsIntegration.hx
@@ -85,12 +85,12 @@ class TestsIntegration
 
 		//Run the unit tests. These do not require any external dependencies
 		if (isUnit) {
-			// runner.add(new utils.TestMiscUnit());
-			// runner.add(new utils.TestPromiseQueue());
-			// runner.add(new utils.TestStreams());
-			// runner.add(new storage.TestStorageRestAPI());
-			// runner.add(new storage.TestStorageLocal());
-			// runner.add(new compute.TestRedisMock());
+			runner.add(new utils.TestMiscUnit());
+			runner.add(new utils.TestPromiseQueue());
+			runner.add(new utils.TestStreams());
+			runner.add(new storage.TestStorageRestAPI());
+			runner.add(new storage.TestStorageLocal());
+			runner.add(new compute.TestRedisMock());
 			if (isInternet) {
 				runner.add(new storage.TestStorageSftp());
 			}
@@ -98,21 +98,21 @@ class TestsIntegration
 
 		if (isRedis) {
 			// These require a local redis db
-			// runner.add(new compute.TestAutoscaling());
-			// runner.add(new compute.TestRedis());
+			runner.add(new compute.TestAutoscaling());
+			runner.add(new compute.TestRedis());
 
 			//These require access to a local docker server
 			if (isDockerProvider) {
-				// runner.add(new compute.TestScheduler());
-				// runner.add(new compute.TestJobStates());
-				// runner.add(new compute.TestInstancePool());
-				// runner.add(new compute.TestComputeQueue());
-				// runner.add(new compute.TestScalingMock());
+				runner.add(new compute.TestScheduler());
+				runner.add(new compute.TestJobStates());
+				runner.add(new compute.TestInstancePool());
+				runner.add(new compute.TestComputeQueue());
+				runner.add(new compute.TestScalingMock());
 
-				// runner.add(new compute.TestCompleteJobSubmissionLocalDocker());
-				// runner.add(new compute.TestRestartAfterCrashLocalDocker());
+				runner.add(new compute.TestCompleteJobSubmissionLocalDocker());
+				runner.add(new compute.TestRestartAfterCrashLocalDocker());
 				runner.add(new compute.TestDockerCompute());
-				// runner.add(new compute.TestServiceBatchCompute());
+				runner.add(new compute.TestServiceBatchCompute());
 			}
 
 			// runner.add(new compute.TestCLIRemoteServerInstallation());

--- a/test/src/compute/TestCompleteJobSubmissionLocalDocker.hx
+++ b/test/src/compute/TestCompleteJobSubmissionLocalDocker.hx
@@ -46,15 +46,15 @@ class TestCompleteJobSubmissionLocalDocker extends TestCompleteJobSubmissionBase
 			});
 	}
 
-	@timeout(1000)
-	public function testSftpConfiguredCorrectly()
-	{
-		return WorkerProviderBoot2Docker.isSftpConfigInLocalDockerMachine()
-			.then(function(ok) {
-				assertTrue(ok);
-				return true;
-			});
-	}
+	// @timeout(1000)
+	// public function testSftpConfiguredCorrectly()
+	// {
+	// 	return WorkerProviderBoot2Docker.isSftpConfigInLocalDockerMachine()
+	// 		.then(function(ok) {
+	// 			assertTrue(ok);
+	// 			return true;
+	// 		});
+	// }
 
 	@timeout(600000) //10m
 	public function testCompleteJobSubmissionLocalDocker()

--- a/test/src/compute/TestDockerCompute.hx
+++ b/test/src/compute/TestDockerCompute.hx
@@ -74,8 +74,13 @@ class TestDockerCompute extends TestComputeBase
 			});
 	}
 
+	/**
+	 * This is obsolete since local docker workers use a locally mounted
+	 * storage volume, not SFTP since the local docker daemon since 1.12
+	 * cannot be ssh'ed into.
+	 */
 	@timeout(500)
-	public function testSshConnectivity()
+	public function OBSOLETEtestSshConnectivity()
 	{
 		var workerDef = _worker;
 		return Promise.promise(true)


### PR DESCRIPTION
- Persist redis db to host volume.
- This keeps the workers saved between server redeployments.
- Also remove some obsolete tests since docker 1.12