### PR TITLE
Disable "append only mode" to avoid huge file size of appended file.

### DIFF
--- a/etc/redis/redis-dev.conf
+++ b/etc/redis/redis-dev.conf
@@ -560,7 +560,7 @@ slave-priority 100
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-appendonly yes
+appendonly no
 
 # The name of the append only file (default: "appendonly.aof")
 

--- a/etc/redis/redis-prod.conf
+++ b/etc/redis/redis-prod.conf
@@ -560,7 +560,7 @@ slave-priority 100
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-appendonly yes
+appendonly no
 
 # The name of the append only file (default: "appendonly.aof")
 


### PR DESCRIPTION
Disable "append only mode" to avoid huge file size of appended file. We do not need that level of durability yet.