### PR TITLE
Fix s3 get file not existing

### DIFF
--- a/src/haxe/ccc/compute/server/tests/TestStorageBase.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStorageBase.hx
@@ -36,6 +36,33 @@ class TestStorageBase extends haxe.unit.async.PromiseTest
 		}
 	}
 
+	@timeout(10000)
+	public function testFileExists() :Promise<Bool>
+	{
+		return _storage.exists('sdfsdfafsadfasdcfsfcasfsadf')
+			.then(function(exists) {
+				assertFalse(exists);
+				return true;
+			})
+			.errorPipe(function(err) {
+				assertIsNull(err);
+				return Promise.promise(false);
+			});
+	}
+
+	@timeout(10000)
+	public function testGettingFileThatDoesNotExist() :Promise<Bool>
+	{
+		return _storage.readFile('sdfsdfafsadfasdcfsfcasfsadf')
+			.then(function(_) {
+				assertTrue(false);
+				return true;
+			})
+			.errorPipe(function(err) {
+				return Promise.promise(true);
+			});
+	}
+
 	function doPathParsing(s :ServiceStorage) :Promise<Bool>
 	{
 		var rootPath = 'rootPathTest/';

--- a/src/haxe/ccc/compute/server/tests/TestStorageBase.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStorageBase.hx
@@ -36,7 +36,7 @@ class TestStorageBase extends haxe.unit.async.PromiseTest
 		}
 	}
 
-	@timeout(10000)
+	@timeout(1200000)
 	public function testFileExists() :Promise<Bool>
 	{
 		return _storage.exists('sdfsdfafsadfasdcfsfcasfsadf')
@@ -50,7 +50,7 @@ class TestStorageBase extends haxe.unit.async.PromiseTest
 			});
 	}
 
-	@timeout(10000)
+	@timeout(120000)
 	public function testGettingFileThatDoesNotExist() :Promise<Bool>
 	{
 		return _storage.readFile('sdfsdfafsadfasdcfsfcasfsadf')

--- a/src/haxe/ccc/compute/server/tests/TestStoragePkgCloud.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStoragePkgCloud.hx
@@ -30,6 +30,18 @@ class TestStoragePkgCloud extends TestStorageBase
 			}));
 	}
 
+	@timeout(10000)
+	override public function testFileExists() :Promise<Bool>
+	{
+		return super.testFileExists();
+	}
+
+	@timeout(10000)
+	override public function testGettingFileThatDoesNotExist() :Promise<Bool>
+	{
+		return super.testGettingFileThatDoesNotExist();
+	}
+
 	// AWS S3 allows path-like object names
 	// @timeout(100)
 	// function TODO_CHECK_THIS_testPathConversion() :Promise<Bool>

--- a/src/haxe/ccc/compute/server/tests/TestStorageS3.hx
+++ b/src/haxe/ccc/compute/server/tests/TestStorageS3.hx
@@ -31,6 +31,18 @@ class TestStorageS3 extends TestStorageBase
 			});
 	}
 
+	@timeout(10000)
+	override public function testFileExists() :Promise<Bool>
+	{
+		return super.testFileExists();
+	}
+
+	@timeout(10000)
+	override public function testGettingFileThatDoesNotExist() :Promise<Bool>
+	{
+		return super.testGettingFileThatDoesNotExist();
+	}
+
 	@timeout(1000)
 	public function testPathsS3() :Promise<Bool>
 	{

--- a/src/haxe/js/npm/aws/AWS.hx
+++ b/src/haxe/js/npm/aws/AWS.hx
@@ -74,6 +74,8 @@ extern class AWSS3
 	// http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#listBuckets-property
 	public function listBuckets(cb :Null<Error>->Dynamic->Void) :Void;
 
+	public function headObject(p :AWSS3ObjectParams, cb :Null<Error>->Dynamic->Void) :Void;
+
 	public function deleteObject(p :AWSS3ObjectParams, cb :Null<Error>->Dynamic->Void) :Void;
 
 	public function listObjectsV2(p :AWSS3ListObjectParams, cb :Null<Error>->Dynamic->Void) :Void;


### PR DESCRIPTION
The ASW SDK throws an internal (non-catchable) error if you create a read stream from a file object that does not exist. So check before downloading.